### PR TITLE
Add actions for the TIDAL desktop app.

### DIFF
--- a/Application Actions/TIDAL/1.0/Decrease Volume.scpt
+++ b/Application Actions/TIDAL/1.0/Decrease Volume.scpt
@@ -1,0 +1,5 @@
+tell application "System Events"
+	tell process "TIDAL"
+		key code 125 using command down
+	end tell
+end tell

--- a/Application Actions/TIDAL/1.0/Increase Volume.scpt
+++ b/Application Actions/TIDAL/1.0/Increase Volume.scpt
@@ -1,0 +1,5 @@
+tell application "System Events"
+	tell process "TIDAL"
+		key code 126 using command down
+	end tell
+end tell

--- a/Application Actions/TIDAL/1.0/Next Track.scpt
+++ b/Application Actions/TIDAL/1.0/Next Track.scpt
@@ -1,0 +1,5 @@
+tell application "System Events"
+	tell process "TIDAL"
+		key code 124 using command down
+	end tell
+end tell

--- a/Application Actions/TIDAL/1.0/Play or Pause.scpt
+++ b/Application Actions/TIDAL/1.0/Play or Pause.scpt
@@ -1,0 +1,5 @@
+tell application "System Events"
+	tell process "TIDAL"
+		keystroke " "
+	end tell
+end tell

--- a/Application Actions/TIDAL/1.0/Play or Pause.scpt
+++ b/Application Actions/TIDAL/1.0/Play or Pause.scpt
@@ -1,5 +1,5 @@
 tell application "System Events"
 	tell process "TIDAL"
-		keystroke " "
+		key code 49
 	end tell
 end tell

--- a/Application Actions/TIDAL/1.0/Previous Track.scpt
+++ b/Application Actions/TIDAL/1.0/Previous Track.scpt
@@ -1,0 +1,5 @@
+tell application "System Events"
+	tell process "TIDAL"
+		key code 123 using command down
+	end tell
+end tell

--- a/Application Actions/TIDAL/1.0/default.json
+++ b/Application Actions/TIDAL/1.0/default.json
@@ -1,0 +1,9 @@
+{
+  "RotateLeft" : "Decrease Volume",
+  "RotateRight" : "Increase Volume",
+  "ButtonPress" : "Play or Pause",
+  "SwipeLeft" : "Previous Track",
+  "SwipeRight" : "Next Track",
+  "FlyLeft" : "Previous Track",
+  "FlyRight" : "Next Track"
+}


### PR DESCRIPTION
Actions for the TIDAL (http://tidal.com/) OSX app.

I use `key code` in this for the arrows but `keystroke` for the space. Not sure if that has a stable key code.
